### PR TITLE
add support for stdout logging

### DIFF
--- a/pkg/utils/logger/logger_test.go
+++ b/pkg/utils/logger/logger_test.go
@@ -57,3 +57,16 @@ func TestLogLevelReturnsDefaultLevelWhenEnvSetToInvalidValue(t *testing.T) {
 	expectedLogLevel = log.InfoLvl
 	assert.Equal(t, expectedLogLevel.String(), getLogLevel())
 }
+
+func TestLogOutputReturnsFileWhenEnvNotSet(t *testing.T) {
+	var expectedOutput = `<rollingfile filename="foo" type="date" datepattern="2006-01-02-15" archivetype="none" maxrolls="24" />`
+	assert.Equal(t, expectedOutput, getLogOutput("foo"))
+}
+
+func TestLogOutputReturnsConsole(t *testing.T) {
+	os.Setenv(envLogOutput, "stdout")
+	defer os.Unsetenv(envLogOutput)
+
+	var expectedOutput = `<console />`
+	assert.Equal(t, expectedOutput, getLogOutput(""))
+}


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/amazon-vpc-cni-k8s/issues/135

*Description of changes:*

- Add env var for log output (log file is default, stdout is only other option)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
